### PR TITLE
Make authentication configurable and required

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -29,3 +29,23 @@ func newSkipSudoFlag(dest *bool) *cli.BoolFlag {
 		Destination: dest,
 	}
 }
+
+func newAuthUserFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:        "auth-user",
+		Usage:       "User name for basic auth",
+		Required:    true,
+		EnvVars:     []string{"AUTH_USER"},
+		Destination: dest,
+	}
+}
+
+func newAuthPassFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:        "auth-pass",
+		Usage:       "Password for basic auth",
+		Required:    true,
+		EnvVars:     []string{"AUTH_PASS"},
+		Destination: dest,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ func NewApp() *cli.App {
 			newLogLevelFlag(),
 			newDryRunFlag(&webCommand.DryRunMode),
 			newSkipSudoFlag(&webCommand.SkipSudo),
+			newAuthUserFlag(&webCommand.AuthUser),
+			newAuthPassFlag(&webCommand.AuthPass),
 		},
 		Action: actions(LogMetadata, webCommand.StartWeb),
 	}

--- a/package/systemd.env
+++ b/package/systemd.env
@@ -1,6 +1,11 @@
 ### General
 
+## (Required) User name for basic auth
+AUTH_USER=
+## (Required) Password for basic auth
+AUTH_PASS=
+
 ### Misc
 
-## Logging level. Allowed values: [debug | warn | error]
+## Logging level. Allowed values: [debug | warn | error | disabled]
 # LOG_LEVEL=info

--- a/web.go
+++ b/web.go
@@ -25,6 +25,8 @@ type WebCommand struct {
 	DryRunMode    bool
 	SkipSudo      bool
 	ListenAddress string
+	AuthUser      string
+	AuthPass      string
 }
 
 type Renderer struct {
@@ -46,10 +48,10 @@ func (c *WebCommand) StartWeb(ctx *cli.Context) error {
 	server.HideBanner = true
 	server.HidePort = true
 
-	server.Use(middleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
+	server.Use(middleware.BasicAuth(func(username, password string, ctx echo.Context) (bool, error) {
 		// Be careful to use constant time comparison to prevent timing attacks
-		if subtle.ConstantTimeCompare([]byte(username), []byte("joe")) == 1 &&
-			subtle.ConstantTimeCompare([]byte(password), []byte("secret")) == 1 {
+		if subtle.ConstantTimeCompare([]byte(username), []byte(c.AuthUser)) == 1 &&
+			subtle.ConstantTimeCompare([]byte(password), []byte(c.AuthPass)) == 1 {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
## Summary

* Adds flag `auth-user` (env: `AUTH_USER`) to configure the basic auth username
* Adds flag `auth-pass` (env: `AUTH_PASS`) to configure the basic auth password
* Both flags are required, else the service doesn't start.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
